### PR TITLE
Unpin certifi dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.4"
-certifi = "^2022.12.7"
+certifi = ">=2022.12.7"
 six = "^1.10"
 python_dateutil = "^2.8.1"
 urllib3 = "^1.15.1"


### PR DESCRIPTION
Caret dependencies prevent this harbor_client to be used with newer certifi versions (2023.x.y and beyond)